### PR TITLE
Fix compatibility with Symfont 5

### DIFF
--- a/src/AdamQuaile/Behat/CommandRunnerExtension/CommandRunnerSubscriber.php
+++ b/src/AdamQuaile/Behat/CommandRunnerExtension/CommandRunnerSubscriber.php
@@ -81,9 +81,7 @@ class CommandRunnerSubscriber implements EventSubscriberInterface
      */
     private function buildProcess($command)
     {
-        $arrayCommand = array_filter( explode(" ", $command) );
-
-        return new Process($arrayCommand);
+        return Process::fromShellCommandline($command);
     }
 
     public function beforeSuite()

--- a/src/AdamQuaile/Behat/CommandRunnerExtension/CommandRunnerSubscriber.php
+++ b/src/AdamQuaile/Behat/CommandRunnerExtension/CommandRunnerSubscriber.php
@@ -81,7 +81,9 @@ class CommandRunnerSubscriber implements EventSubscriberInterface
      */
     private function buildProcess($command)
     {
-        return new Process($command);
+        $arrayCommand = array_filter( explode(" ", $command) );
+
+        return new Process($arrayCommand);
     }
 
     public function beforeSuite()


### PR DESCRIPTION
In symfony 5 the Process constructor has been changed from 
`public function __construct($command, string $cwd = null, array $env = null, $input = null, ?float $timeout = 60)`
to
`public function __construct(array $command, string $cwd = null, array $env = null, $input = null, ?float $timeout = 60)`

Now the `$command` argument is type hinted and can only accept array and each argument of the command should be on a separate element so passing a whole command with its arguments as a string is no more accepted.

Here I am splitting the command string into array an passing it so we keep backward compatibility and also allow the use of this extension with symfony 5.