### PR TITLE
Pin to range symfony process version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "require": {
         "behat/behat": "~3.0",
-        "symfony/process": "*"
+        "symfony/process": ">=2 <6"
     },
     "authors": [
         {


### PR DESCRIPTION
Fix https://github.com/adamquaile/behat-command-runner-extension/issues/3

This was running OK from Symfony 2 until a BC with Symfony 5 that is to be fixed by https://github.com/adamquaile/behat-command-runner-extension/pull/2

After that we can pin the version of Symfony Process component used here to a range >=2 and <6